### PR TITLE
use section rather than section number for REMIU compatibility

### DIFF
--- a/renderer.php
+++ b/renderer.php
@@ -147,7 +147,7 @@ class format_flexsections_renderer extends plugin_renderer_base {
         // display section content
         echo html_writer::start_tag('div', array('class' => 'content'));
         // display section name and expanded/collapsed control
-        if ($sectionnum && ($title = $this->section_title($sectionnum, $course, ($level == 0) || !$contentvisible))) {
+        if ($section && ($title = $this->section_title($section, $course, ($level == 0) || !$contentvisible))) {
             if ($collapsedcontrol) {
                 $title = $this->render($collapsedcontrol). $title;
             }


### PR DESCRIPTION
I'm trying to get the flexsections course format to be compatible with the "remui" theme (see https://edwiser.org/remui/ ). As part of this, the call to section_title needs to use a section object rather than a number. This change adds that. I am not sufficiently familiar with the course format / theme tradeoffs to know if it's not reasonable for the theme to assume this is the case, but later in the code flow $section -> course is used and this doesn't work if sectionnum is passed in.