### PR TITLE
Implement weekly layout.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [4.0.6] - Unreleased
+### Added
+- Add an option to format settings that allows emulating weekly format in a way
+  where top level sections will be named after weeks. This does not apply to subsections.
+
 ## [4.0.5] - 2023-08-08
 ### Fixed
 - When scrolling the page, the course index now correctly highlights subsections.

--- a/classes/event/observer.php
+++ b/classes/event/observer.php
@@ -1,0 +1,49 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace format_flexsections\event;
+
+/**
+ * Event observers for flexible sections course format.
+ *
+ * @package    format_flexsections
+ * @copyright  2022 Ruslan Kabalin
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class observer {
+
+    /**
+     * Triggered via \core\event\course_updated event.
+     *
+     * @param \core\event\course_updated $event
+     */
+    public static function course_updated(\core\event\course_updated $event) {
+        if (class_exists('format_flexsections', false)) {
+            \format_flexsections::update_end_date($event->courseid);
+        }
+    }
+
+    /**
+     * Triggered via \core\event\course_section_deleted event.
+     *
+     * @param \core\event\course_section_deleted $event
+     */
+    public static function course_section_deleted(\core\event\course_section_deleted $event) {
+        if (class_exists('format_flexsections', false)) {
+            \format_flexsections::update_end_date($event->courseid);
+        }
+    }
+}

--- a/classes/output/courseformat/content/section/controlmenu.php
+++ b/classes/output/courseformat/content/section/controlmenu.php
@@ -83,7 +83,8 @@ class controlmenu extends \core_courseformat\output\local\content\section\contro
             ];
         }
 
-        if ($section->section && has_capability('moodle/course:setcurrentsection', $coursecontext)) {
+        if ($course->layout !== FORMAT_FLEXSECTIONS_LAYOUT_WEEKLY && $section->section
+                && has_capability('moodle/course:setcurrentsection', $coursecontext)) {
             $markerurl = new \moodle_url($url);
             if ($course->marker == $section->section) {  // Show the "light globe" on/off.
                 $markerurl->param('marker', 0);

--- a/db/events.php
+++ b/db/events.php
@@ -15,19 +15,22 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Version details.
+ * Event handlers definition for flexible sections course format.
  *
  * @package    format_flexsections
- * @copyright  2022 Marina Glancy
+ * @copyright  2022 Ruslan Kabalin
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-defined('MOODLE_INTERNAL') || die();
+defined('MOODLE_INTERNAL') || die;
 
-$plugin->version   = 2023080801;             // The current plugin version (Date: YYYYMMDDXX).
-$plugin->requires  = 2022041900.00;          // Requires Moodle 4.0 or above.
-$plugin->release   = "4.0.5";
-$plugin->maturity  = MATURITY_STABLE;
-$plugin->component = 'format_flexsections';  // Full name of the plugin (used for diagnostics).
-$plugin->supported = [400, 402];
-
+$observers = [
+    [
+        'eventname'   => '\core\event\course_updated',
+        'callback'    => '\format_flexsections\event\observer::course_updated',
+    ],
+    [
+        'eventname'   => '\core\event\course_section_deleted',
+        'callback'    => '\format_flexsections\event\observer::course_section_deleted',
+    ]
+];

--- a/lang/en/format_flexsections.php
+++ b/lang/en/format_flexsections.php
@@ -26,6 +26,8 @@ $string['accordion'] = 'Accordion effect';
 $string['accordiondesc'] = 'When one section is expanded, collapse all others.';
 $string['addsections'] = 'Add section';
 $string['addsubsection'] = 'Add subsection';
+$string['automaticenddate'] = 'For weekly layout calculate the end date from the number of sections';
+$string['automaticenddate_help'] = 'If enabled, the end date for the course will be automatically calculated from the number of sections and the course start date.';
 $string['backtocourse'] = 'Back to course \'{$a}\'';
 $string['backtosection'] = 'Back to \'{$a}\'';
 $string['cmbacklink'] = 'Display back link in activities';
@@ -46,6 +48,13 @@ $string['errorsectiondepthexceeded'] = 'Subsection depth has exceeded configured
 $string['hidefromothers'] = 'Hide section';
 $string['maxsectiondepth'] = 'Max subsection depth';
 $string['maxsectiondepthdesc'] = 'Maximum number of subsection levels.';
+$string['layout'] = 'Layout';
+$string['layout_help'] = 'Choose flexsections layout:
+
+* Topics - this emulates topics format, each subsection will be numbered consecutively.
+* Weekly - this emulates weekly format in a way where top level sections will be named after weeks. This does not apply to subsections.';
+$string['layouttopics'] = 'Topics layout';
+$string['layoutweekly'] = 'Weekly layout';
 $string['mergeup'] = 'Merge with parent';
 $string['moveassubsection'] = 'As a subsection of \'{$a}\'';
 $string['movebeforecm'] = 'Before activity \'{$a}\'';
@@ -68,6 +77,7 @@ $string['showsection0title'] = 'Show top section title';
 $string['showsection0title_help'] = 'When enabled, the general section will have a title and will be collapsible, same as it behaves in the Topics format.';
 $string['showsection0titledefault'] = 'Show top section title by default';
 $string['showsection0titledefaultdesc'] = 'This defines default setting that will be used for new and existing courses, it can be changed for individual courses in their settings.';
+$string['subtopic'] = 'Subtopic';
 
 // Deprecated but still can be used in 4.0, to be removed when we have a branch for Moodle 4.1 or later.
 $string['addsection'] = 'Add section';


### PR DESCRIPTION
This patch adds an option to format settings that allows emulating weekly format in a way where top level sections will be named after weeks:
![image](https://user-images.githubusercontent.com/329780/180666639-3c3fef49-de26-4387-acc6-d62c3088af62.png)

This does not apply to subsections. When in use, the layout is similar to:

![image](https://user-images.githubusercontent.com/329780/180666489-b7948ac4-b023-4504-b769-b107da00c6b0.png)

(notice the patch contains commit from PR #28 which should be merged first)