### PR TITLE
Add composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,22 @@
+{
+    "name": "marinaglancy/moodle-format_flexsections",
+    "description": "Flexible sections course format",
+    "license": "GPL-3.0-or-later",
+    "authors": [
+        {
+            "name": "Marina Glancy",
+            "email": "marina.glancy@gmail.com"
+        }
+    ],
+    "type": "moodle-format",
+    "require": {
+        "composer/installers": "~1.0"
+    },
+    "extra": {
+        "installer-name": "flexsections"
+    },
+    "support": {
+        "issues": "https://github.com/marinaglancy/moodle-format_flexsections/issues",
+        "source": "https://github.com/marinaglancy/moodle-format_flexsections"
+    }
+}


### PR DESCRIPTION
This is to make possible installation using composer, which support [moodle plugin types](https://github.com/composer/installers/blob/main/src/Composer/Installers/MoodleInstaller.php) nowadays.

Quick intro:
- `"type": "moodle-format"` make plugin install into `course/format/<name>` dir
- `"installer-name": "flexsections"` makes installed dir name `flexsections` rather than `marinaglancy/moodle-format_flexsections`
- the rest is self explanatory

Once merged, publishing on [packagst](https://packagist.org/) it required. It traces tags in repo, so no further steps after initial publishing will be required, all further releases will be published automatically.