### PR TITLE
Course index - always display all sections and activities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [4.0.2] - Unreleased
+### Changed
+- Course index always shows all sections and activities regardless of the current page. More details
+  https://github.com/marinaglancy/moodle-format_flexsections/issues/39
+
 ## [4.0.1] - 2022-06-19
 ### Added
 - Course format "Flexible sections" now has UI in-line with the Moodle LMS 4.0 course formats. It supports AJAX editing of activities and sections and course index.

--- a/classes/output/courseformat/state/course.php
+++ b/classes/output/courseformat/state/course.php
@@ -37,25 +37,17 @@ class course extends \core_courseformat\output\local\state\course {
     public function export_for_template(\renderer_base $output): \stdClass {
         $data = parent::export_for_template($output);
 
-        $viewedsection = $this->format->get_viewed_section();
-        if ($viewedsection) {
-            $s = $this->format->get_section($viewedsection);
-            $data->sectionlist = [$s->id];
-        } else {
-            $data->sectionlist = array_values(array_filter($data->sectionlist,
-                function($sectionid) {
-                    $section = $this->format->get_modinfo()->get_section_info_by_id($sectionid);
-                    return $section && !$section->parent;
-                }));
-        }
+        $data->sectionlist = array_values(array_filter($data->sectionlist,
+            function($sectionid) {
+                $section = $this->format->get_modinfo()->get_section_info_by_id($sectionid);
+                return $section && !$section->parent;
+            }));
 
         // Build sections hierarchy.
         $allsections = $this->format->get_modinfo()->get_section_info_all();
         $res1 = $res2 = [];
-        $toinclude = [$viewedsection ?: 0];
         foreach ($allsections as $s) {
-            if ($s->section && $this->format->is_section_visible($s) &&
-                    (in_array($s->parent, $toinclude) || ($viewedsection && $s->section == $viewedsection))) {
+            if ($s->section && $this->format->is_section_visible($s)) {
                 $children = [];
                 foreach ($allsections as $ss) {
                     if ($ss->parent == $s->section) {
@@ -67,7 +59,6 @@ class course extends \core_courseformat\output\local\state\course {
                 } else {
                     $res2[] = ['id' => $s->id, 'section' => $s->section, 'children' => $children];
                 }
-                $toinclude[] = $s->section;
             }
         }
         // Function _fixOrder in lib/amd/src/local/reactive/basecomponent.js removes all existing children of empty lists

--- a/classes/output/courseformat/state/section.php
+++ b/classes/output/courseformat/state/section.php
@@ -44,9 +44,7 @@ class section extends \core_courseformat\output\local\state\section {
         $showaslink = $this->section->collapsed == FORMAT_FLEXSECTIONS_COLLAPSED
             && $this->format->get_viewed_section() != $this->section->section;
         $data->children = [];
-        if ($showaslink) {
-            $data->cmlist = [];
-        } else if ($this->section->section) {
+        if ($this->section->section) {
             foreach ($this->format->get_modinfo()->get_section_info_all() as $s) {
                 if ($s->parent == $this->section->section && $this->format->is_section_visible($s)) {
                     $data->children[] = (array)((new static($this->format, $s))->export_for_template($output)) +

--- a/tests/behat/basic_actions.feature
+++ b/tests/behat/basic_actions.feature
@@ -102,9 +102,9 @@ Feature: Using course in flexsections format
     And I am on "Course 1" course homepage
     Then I should see "Topic 1" in the "region-main" "region"
     And I should see "Topic 1" in the "Navigation" "block"
-    And I should not see "First module"
-    And I should not see "Topic 2"
-    And I should not see "Second module"
+    And I should not see "First module" in the "region-main" "region"
+    And I should not see "Topic 2" in the "region-main" "region"
+    And I should not see "Second module" in the "region-main" "region"
     And I click on "Topic 1" "link" in the "region-main" "region"
     And I should see "Topic 1" in the "region-main" "region"
     And I should see "First module" in the "region-main" "region"


### PR DESCRIPTION
To address https://github.com/marinaglancy/moodle-format_flexsections/issues/39 and https://github.com/marinaglancy/moodle-format_flexsections/issues/33

The solution is to always display all sections and all modules in the course index, even when we are in the subsections displayed on a separate page.