### PR TITLE
Fix find_next_section behaviour in complex tree scenario.

### DIFF
--- a/classes/courseformat/stateactions.php
+++ b/classes/courseformat/stateactions.php
@@ -86,22 +86,20 @@ class stateactions extends  \core_courseformat\stateactions {
     }
 
     /**
-     * Find next section
+     * Find next section within the same parent.
      *
      * @param \course_modinfo $modinfo
      * @param \section_info $thissection
      * @return \section_info|null
      */
     protected function find_next_section(\course_modinfo $modinfo, \section_info $thissection): ?\section_info {
-        $found = false;
-        foreach ($modinfo->get_section_info_all() as $section) {
-            if ($found) {
-                return $section->parent == $thissection->parent ? $section : null;
-            } else if ($section->id == $thissection->id) {
-                $found = true;
-            }
-        }
-        return null;
+        // Build array of same parent sections starting from next to $thissection.
+        $sections = array_filter($modinfo->get_section_info_all(), function($s) use ($thissection) {
+            return ($s->parent == $thissection->parent) && ($s->section > $thissection->section);
+        });
+
+        // Empty array means $thissection is last section, otherwise the first section is the one we need.
+        return empty($sections) ? null : array_shift($sections);
     }
 
     /**


### PR DESCRIPTION
This patch makes `find_next_section` respect cases where requested section contains subsections, it fixes:

* Do not return null if requested section contains subsections.
* Make it identify the last section correctly.

Scenarios to test this patch:
1. Setup sections as:
```
section1
    section2
    section3
        section4
    section5 (add activity to observe where section is moved)
    section6
section7
    section8
section9
```
2. From scenario at step 1 move section5 before section 7 (before this patch section5 will become the last section8)
3. From scenario at step 1 move section6 before section 5 (before this patch section6 will not move)

Fixes #37 (hopefully)