### PR TITLE
Fixes the error that occurs when the hook is called.

### DIFF
--- a/classes/local/hooks/output/before_footer_html_generation.php
+++ b/classes/local/hooks/output/before_footer_html_generation.php
@@ -15,6 +15,7 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 namespace format_flexsections\local\hooks\output;
+require_once($CFG->dirroot.'/course/format/flexsections/lib.php');
 
 /**
  * Hook callbacks for format_flexsections
@@ -33,7 +34,7 @@ class before_footer_html_generation {
      * @param \core\hook\output\before_footer_html_generation $hook
      */
     public static function callback(\core\hook\output\before_footer_html_generation $hook): void {
-        global $OUTPUT;
+        global $OUTPUT, $CFG;
 
         if (during_initial_install() || isset($CFG->upgraderunning)) {
             // Do nothing during installation or upgrade.

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2024100600;             // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2024100601;             // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2022112800.00;          // Requires Moodle 4.1 or above.
 $plugin->release   = "4.1.2";
 $plugin->maturity  = MATURITY_STABLE;


### PR DESCRIPTION
![grafik](https://github.com/user-attachments/assets/a3b73fa6-b0c7-4803-bd3b-3088d56c4973)

The error occurs on our login screen and also on the course overview page, for example.
Tested on Moodle 4.5