### PR TITLE
Bulk Editing sticky footer

### DIFF
--- a/templates/local/content.mustache
+++ b/templates/local/content.mustache
@@ -112,6 +112,11 @@
             {{/sectionselector}}
         </div>
     {{/hasnavigation}}
+    {{#bulkedittools}}
+        {{$ core_courseformat/local/content/bulkedittools}}
+            {{> core_courseformat/local/content/bulkedittools}}
+        {{/ core_courseformat/local/content/bulkedittools}}
+    {{/bulkedittools}}
 </div>
 {{#js}}
     require(['format_flexsections/local/content'], function(component) {


### PR DESCRIPTION
Added bulk editing tools sticky footer to /templates/local/content/content.mustache to enable Bulk Editing to work with Flex Sections. for addressing issue #67 