### PR TITLE
format_flexsections: fix hide/show recursively

### DIFF
--- a/classes/courseformat/stateactions.php
+++ b/classes/courseformat/stateactions.php
@@ -361,6 +361,39 @@ class stateactions extends  \core_courseformat\stateactions {
     }
 
     /**
+     * Show or hide course sections recursively.
+     *
+     * @param stateupdates $updates the affected course elements track
+     * @param stdClass $course the course object
+     * @param int[] $ids section ids
+     * @param int $visible the new visible value
+     */
+    protected function set_section_visibility(
+        stateupdates $updates,
+        stdClass $course,
+        array $ids,
+        int $visible
+    ) {
+        global $DB;
+        $format  = course_get_format($course);
+        if (!$format instanceof \format_flexsections) {
+            return;
+        }
+        foreach ($ids as $id) {
+            $sectionnum = $DB->get_field('course_sections', 'section', ['id' => $id]);
+            $section = $format->get_section($sectionnum);
+            // Set visiblity to all child sections.
+            if ($subsections = $format->get_subsections($section)) {
+                foreach ($subsections as $subsection) {
+                    $this->set_section_visibility($updates, $course, [$subsection->id], $visible);
+                }
+            }
+
+        }
+        parent::set_section_visibility($updates, $course, $ids, $visible);
+    }
+
+    /**
      * Switch collapsed state (display as link/ display on the same page)
      *
      * @param \core_courseformat\stateupdates $updates


### PR DESCRIPTION
Hi Marina,
We use your format plugin quite frequently.
Recently, we noticed a strange behavior:
when a section that contains subsections is hidden, the activities within those subsections remain accessible to participants.
This PR includes a fix that applies the hiding recursively, ensuring that activities in deeper subsections are also hidden.
The same fix also works for the Moodle 4.5 version, so I’ll open a second PR for the `MOODLE_401_STABLE` branch as well.
It would be great if you could merge this change, or—if you have another preferred solution—implement it so that activities in subsections are properly protected from access.
Thanks a lot for the great plugin!