### PR TITLE
Prevent flexsections restore cleanup on non-flexsections courses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [5.0.4] - 2026-07-02
+### Fixed
+- Restore cleanup no longer runs when restoring into courses using another course format
+
 ## [5.0.3] - 2026-04-17
 ### Fixed
 - Missing sesskey validation for `addchildsection` and `movesection` URL handlers in non-JS fallbacks -

--- a/backup/moodle2/restore_format_flexsections_plugin.class.php
+++ b/backup/moodle2/restore_format_flexsections_plugin.class.php
@@ -83,6 +83,11 @@ class restore_format_flexsections_plugin extends restore_format_plugin {
 
         $courseid = $this->step->get_task()->get_courseid();
 
+        $format = $DB->get_field('course', 'format', ['id' => $courseid]);
+        if ($format !== 'flexsections') {
+            return;
+        }
+
         // Get all sections and their parent format options.
         $sections = $DB->get_records(
             'course_sections',

--- a/version.php
+++ b/version.php
@@ -24,9 +24,9 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2026041700;             // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2026070200;             // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2025041400.00;          // Requires Moodle 5.0 or above.
-$plugin->release   = "5.0.3";
+$plugin->release   = "5.0.4";
 $plugin->maturity  = MATURITY_STABLE;
 $plugin->component = 'format_flexsections';  // Full name of the plugin (used for diagnostics).
 $plugin->supported = [500, 502];


### PR DESCRIPTION
Added a small guard to make sure the active theme for the restored course is format_flexsections.

same Issue as: https://github.com/marinaglancy/moodle-format_flexsections/issues/121